### PR TITLE
Fix stored XSS in tour 'Override when saving' path

### DIFF
--- a/class-tours.php
+++ b/class-tours.php
@@ -85,6 +85,42 @@ class Tours {
 	}
 
 	/**
+	 * Sanitize a decoded tour structure field-by-field, for the context each field is rendered in.
+	 *
+	 * @param      array $tour  The decoded tour (untrusted).
+	 *
+	 * @return     array  The sanitized tour.
+	 */
+	private static function sanitize_tour( $tour ) {
+		$sanitized = array();
+
+		if ( isset( $tour[0] ) && is_array( $tour[0] ) ) {
+			$color       = isset( $tour[0]['color'] ) ? $tour[0]['color'] : '';
+			$sanitized[] = array(
+				'color' => ( is_string( $color ) && preg_match( '/^#[0-9a-fA-F]{3,8}$/', $color ) ) ? $color : '#3939c7',
+				'title' => sanitize_text_field( isset( $tour[0]['title'] ) ? $tour[0]['title'] : '' ),
+			);
+		}
+
+		for ( $i = 1, $count = count( $tour ); $i < $count; $i++ ) {
+			$step = $tour[ $i ];
+			if ( ! is_array( $step ) || ! isset( $step['element'] ) || ! isset( $step['popover'] ) || ! is_array( $step['popover'] ) ) {
+				continue;
+			}
+
+			$sanitized[] = array(
+				'element' => sanitize_text_field( is_array( $step['element'] ) ? '' : $step['element'] ),
+				'popover' => array(
+					'title'       => sanitize_text_field( isset( $step['popover']['title'] ) ? $step['popover']['title'] : '' ),
+					'description' => wp_kses_post( isset( $step['popover']['description'] ) ? $step['popover']['description'] : '' ),
+				),
+			);
+		}
+
+		return $sanitized;
+	}
+
+	/**
 	 * Register the post type.
 	 */
 	public static function register_post_type() {
@@ -348,7 +384,11 @@ class Tours {
 		);
 
 		if ( isset( $_POST['override_json'] ) ) {
-			$data['post_content'] = wp_kses_post( $_POST['json'] );
+			$tour = json_decode( wp_unslash( $_POST['json'] ), true );
+			if ( ! is_array( $tour ) ) {
+				return $data;
+			}
+			$data['post_content'] = wp_json_encode( wp_slash( self::sanitize_tour( $tour ) ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 			return $data;
 		}
 


### PR DESCRIPTION
## Summary

Fixes a stored XSS in the "Override when saving" branch of `Tours::wp_insert_post_data()` (`class-tours.php`). That branch ran `wp_kses_post()` — an HTML sanitizer — over the raw JSON textarea contents before `json_decode()`. JSON's `\uXXXX` escapes carry no HTML metacharacters, so the sanitizer had nothing to strip; `json_decode()` then manufactured live `<`/`>`/event-handler markup afterward. That markup reaches every Editor/Administrator's admin bar via `wp_localize_script()` and is rendered by `driver.js` with `innerHTML`, and `Tours::tour_list()` deliberately widens its query to include drafts for `edit_others_posts` users — so a Contributor (who only needs `edit_posts` to create/save a `tour` draft, since the post type registers with no capability map) can get script execution in an Administrator's session with no publish/approval step.

## Fix

Replaced the raw-string sanitize with decode → validate → sanitize-per-field → re-encode, mirroring the filter the plugin's own non-override save path already applies:

- `Tours::sanitize_tour()` validates the decoded array shape and applies `sanitize_text_field()` to `title`/`element`, a hex-color regex to `color` (falling back to the default), and `wp_kses_post()` only to `popover.description`.
- The override branch now does `json_decode` → `is_array()` check → `sanitize_tour()` → `wp_json_encode(wp_slash(...))`, matching the encoding used by the normal save path.

Verified against a payload like `<details open ontoggle=alert(document.domain)>...` (submitted JSON-escaped, e.g. `<details...`) that the decoded, re-sanitized output no longer carries the `ontoggle` handler.

## Test plan

- [x] `php -l class-tours.php`
- [x] Standalone harness confirming a crafted payload's event-handler attribute is stripped after sanitization
- [ ] Manual: as a Contributor, save a tour with "Override when saving" checked and a payload containing HTML/JS; confirm it's stored sanitized and does not execute when viewed as an Administrator
- [ ] Manual: confirm normal (non-override) tour editing still works unaffected